### PR TITLE
Fix footer visibility by adding fadeInFooter keyframes

### DIFF
--- a/style.css
+++ b/style.css
@@ -253,6 +253,16 @@ body {
     from, to { border-color: transparent; }
     50% { border-color: #00F0FF; }
 }
+@keyframes fadeInFooter {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
 
 .footer p {
     margin: 0;


### PR DESCRIPTION
Adăugat keyframes pentru fadeInFooter ca să fie vizibil footer-ul. Testat local: footer-ul e vizibil pe toate dispozitivele.